### PR TITLE
feat: Add 30m window

### DIFF
--- a/grafana/dashboards/sli-detail.json
+++ b/grafana/dashboards/sli-detail.json
@@ -23,14 +23,17 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "id": 2,
-  "iteration": 1720609910867,
+  "iteration": 1720947434025,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -81,7 +84,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "slo:sli:ratio_rate5m{slo_id=~\"$slo_id\"}",
+          "expr": "slo:sli:ratio_rate$window{slo_id=~\"$slo_id\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -205,7 +208,10 @@
       "type": "stat"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -260,7 +266,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "1 - (1 - slo:sli:ratio_rate5m{slo_id=~\"$slo_id\"}) / (1 - $slo)",
+          "expr": "1 - (1 - slo:sli:ratio_rate$window{slo_id=~\"$slo_id\"}) / (1 - $slo)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -270,7 +276,10 @@
       "type": "stat"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -363,7 +372,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "slo:sli:ratio_rate5m{slo_id=~\"$slo_id\"}",
+          "expr": "slo:sli:ratio_rate$window{slo_id=~\"$slo_id\"}",
           "interval": "",
           "legendFormat": "SLI",
           "refId": "A"
@@ -383,7 +392,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -476,7 +488,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "1 - (1 - slo:sli:ratio_rate5m{slo_id=~\"$slo_id\"}) / (1 - $slo)",
+          "expr": "1 - (1 - slo:sli:ratio_rate$window{slo_id=~\"$slo_id\"}) / (1 - $slo)",
           "interval": "",
           "legendFormat": "Error Budget",
           "refId": "A"
@@ -495,8 +507,8 @@
       {
         "current": {
           "selected": true,
-          "text": "info-request-avaialbility",
-          "value": "info-request-avaialbility"
+          "text": "info-request-availability",
+          "value": "info-request-availability"
         },
         "datasource": {
           "type": "prometheus",
@@ -524,7 +536,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "0.95",
           "value": "0.95"
         },
@@ -546,11 +558,44 @@
           },
           {
             "selected": false,
+            "text": "0.98",
+            "value": "0.98"
+          },
+          {
+            "selected": false,
             "text": "0.99",
             "value": "0.99"
           }
         ],
-        "query": "0.9,0.95,0.99",
+        "query": "0.9,0.95,0.98,0.99",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "30m",
+          "value": "30m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Window",
+        "multi": false,
+        "name": "window",
+        "options": [
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": true,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "5m,30m",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
@@ -558,7 +603,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -577,6 +622,6 @@
   "timezone": "",
   "title": "SLI Detail",
   "uid": "_CRt9oEIk",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }

--- a/grafana/dashboards/sli-overview.json
+++ b/grafana/dashboards/sli-overview.json
@@ -26,7 +26,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 3,
-  "iteration": 1720609896482,
+  "iteration": 1720957669523,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -79,7 +79,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "count(slo:sli:ratio_rate5m{feature=~\"$feature\"})",
+          "expr": "count(slo:sli:ratio_rate$window{feature=~\"$feature\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -89,7 +89,10 @@
       "type": "stat"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -134,7 +137,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "count(count by(feature) (slo:sli:ratio_rate5m{feature=~\"$feature\"}))",
+          "expr": "count(count by(feature) (slo:sli:ratio_rate$window{feature=~\"$feature\"}))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -144,7 +147,10 @@
       "type": "stat"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -193,7 +199,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "count(1 - (1 - slo:sli:ratio_rate5m{feature=~\"$feature\"}) / (1 - $slo) < 0) or vector(0)",
+          "expr": "count(1 - (1 - slo:sli:ratio_rate$window{feature=~\"$feature\"}) / (1 - $slo) < 0) or vector(0)",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -204,7 +210,10 @@
       "type": "stat"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -369,7 +378,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "1 - (1 - slo:sli:ratio_rate5m{feature=~\"$feature\"}) / (1 - $slo)",
+          "expr": "1 - (1 - slo:sli:ratio_rate$window{feature=~\"$feature\"}) / (1 - $slo)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -377,7 +386,7 @@
           "refId": "A"
         }
       ],
-      "title": "Remaining Error Budgets (7 day window)",
+      "title": "Remaining Error Budgets ($window window)",
       "type": "table"
     }
   ],
@@ -389,7 +398,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "All"
           ],
@@ -422,7 +431,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "0.9",
           "value": "0.9"
         },
@@ -444,11 +453,44 @@
           },
           {
             "selected": false,
+            "text": "0.98",
+            "value": "0.98"
+          },
+          {
+            "selected": false,
             "text": "0.99",
             "value": "0.99"
           }
         ],
-        "query": "0.9,0.95,0.99",
+        "query": "0.9,0.95,0.98,0.99",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "30m",
+          "value": "30m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Window",
+        "multi": false,
+        "name": "window",
+        "options": [
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": true,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "5m,30m",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
@@ -456,7 +498,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -475,6 +517,6 @@
   "timezone": "",
   "title": "SLI Overview",
   "uid": "3fXM8uLIk",
-  "version": 2,
+  "version": 6,
   "weekStart": ""
 }

--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -9,6 +9,14 @@ groups:
       labels:
         slo_id: status-request-latency
         feature: status
+    - record: "slo:sli:ratio_rate30m"
+      expr: |-
+        sum(rate(example_request_latency_ms_bucket{url="/ping/:id/status",le="500"}[30m]))
+        /
+        sum(rate(example_request_latency_ms_count{url="/ping/:id/status"}[30m]))
+      labels:
+        slo_id: status-request-latency
+        feature: status
 
   - name: status-request-availability
     rules:
@@ -17,6 +25,14 @@ groups:
         sum(rate(example_requests_count{url="/ping/:id/status",status!~"5..|4.."}[5m]))
         /
         sum(rate(example_request_latency_ms_count{url="/ping/:id/status"}[5m]))
+      labels:
+        slo_id: status-request-availability
+        feature: status
+    - record: "slo:sli:ratio_rate30m"
+      expr: |-
+        sum(rate(example_requests_count{url="/ping/:id/status",status!~"5..|4.."}[30m]))
+        /
+        sum(rate(example_request_latency_ms_count{url="/ping/:id/status"}[30m]))
       labels:
         slo_id: status-request-availability
         feature: status
@@ -31,6 +47,14 @@ groups:
       labels:
         slo_id: info-request-latency
         feature: info
+    - record: "slo:sli:ratio_rate30m"
+      expr: |-
+        sum(rate(example_request_latency_ms_bucket{url="/ping/:id/info",le="500"}[30m]))
+        /
+        sum(rate(example_request_latency_ms_count{url="/ping/:id/info"}[30m]))
+      labels:
+        slo_id: info-request-latency
+        feature: info
 
   - name: info-request-availability
     rules:
@@ -42,3 +66,12 @@ groups:
       labels:
         slo_id: info-request-availability
         feature: info
+    - record: "slo:sli:ratio_rate30m"
+      expr: |-
+        sum(rate(example_requests_count{url="/ping/:id/info",status!~"5..|4.."}[30m]))
+        /
+        sum(rate(example_request_latency_ms_count{url="/ping/:id/info"}[30m]))
+      labels:
+        slo_id: info-request-availability
+        feature: info
+


### PR DESCRIPTION
- Added SLO for 30m window (as well as 5m window).
- Allow Overview and Details to switch between both windows.
- Use a shared crosshair/cursor in Details dashboard.